### PR TITLE
Feat: `hosts` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.DS_Store
 .vscode
 node_modules
 *.log*
+coverage
 dist

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ interface GetPortOptions {
   port?: number
   ports?: number[]
   host?: string
+  hosts?: string[]
 
   memoDir?: string
   memoName?: string
@@ -63,14 +64,20 @@ Alternative ports to check. Default is `[4000, 5000, 6000, 7000]`
 
 ### `host`
 
-The host to check. Default is `process.env.HOST || '0.0.0.0'`
+The host to check for available port. Default is `process.env.HOST`.
+
+### `hosts`
+
+List of hosts to check. The returned port will be not in use on *all* the hosts. Default is `['0.0.0.0', '127.0.0.1']`.
+
+**Note:** if `host` option is set, `hosts` will be ignored.
 
 ### `memoDir` / `memoName`
 
 Options passed to [fs-memo](https://github.com/unjs/fs-memo)
 
 - Default dir: `node_modules/get-port/dist`
-- Defalt name: `.get-port`
+- Default name: `.get-port`
 
 ## License
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,8 @@
 import type { Config } from '@jest/types'
 
 const config: Config.InitialOptions = {
+  collectCoverage: true,
+  collectCoverageFrom: ['<rootDir>/src/**/*.ts'],
   preset: 'ts-jest',
   testEnvironment: 'node'
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "siroc build",
     "lint": "eslint --ext ts .",
     "release": "yarn build && standard-version && npm publish && git push --follow-tags",
-    "test": "jest"
+    "test": "jest --runInBand"
   },
   "dependencies": {
     "fs-memo": "^1.2.0"

--- a/test/host.test.ts
+++ b/test/host.test.ts
@@ -1,0 +1,45 @@
+import { Server } from 'net'
+import { getPort } from '../src'
+import { blockPort } from './utils'
+
+let portBlocker: Server
+
+afterEach(() => {
+  portBlocker?.close()
+})
+
+describe('getPort (host)', () => {
+  test('default port is NOT IN USE', async () => {
+    const port = await getPort({ host: '0.0.0.0' })
+    expect(port).toEqual(3000)
+  })
+
+  test('default port is IN USE', async () => {
+    portBlocker = await blockPort(3000, '0.0.0.0')
+    const port = await getPort({ host: '0.0.0.0' })
+    expect(port).toEqual(4000)
+  })
+
+  test('called with not valid value', async () => {
+    const host = 'not-valid-host'
+    await expect(getPort({ host })).rejects.toThrow()
+  })
+})
+
+describe('getPort (hosts)', () => {
+  test('default port is NOT IN USE', async () => {
+    const port = await getPort({ hosts: ['0.0.0.0'] })
+    expect(port).toEqual(3000)
+  })
+
+  test('default port is IN USE', async () => {
+    portBlocker = await blockPort(3000, '0.0.0.0')
+    const port = await getPort({ hosts: ['0.0.0.0'] })
+    expect(port).toEqual(4000)
+  })
+
+  test('called with not valid value', async () => {
+    const hosts = ['0.0.0.0', 'not-valid-host']
+    await expect(getPort({ hosts })).rejects.toThrow()
+  })
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,45 +1,77 @@
 import { Server } from 'net'
 import { getPort } from '../src'
-import { blockPort } from './utils'
+import { blockPort, blockPorts } from './utils'
 
-describe('getPort ()', () => {
-  describe('checks ports on default host`', () => {
-    let portBlocker: Server
+let portBlocker: Server
+let portBlockers: Server[]
 
-    afterEach(() => {
-      portBlocker?.close()
-    })
-
-    test('default port is NOT IN USE', async () => {
-      const port = await getPort()
-      expect(port).toEqual(3000)
-    })
-
-    test('default port is in use', async () => {
-      portBlocker = await blockPort(3000)
-      const port = await getPort()
-      expect(port).toEqual(4000)
-    })
+afterEach(() => {
+  portBlocker?.close()
+  portBlockers?.forEach((blocker) => {
+    blocker.close()
   })
 })
 
-describe('getPort (host)', () => {
-  describe('checks ports on `localhost`', () => {
-    let portBlocker: Server
+describe('getPort ()', () => {
+  test('default port is NOT IN USE', async () => {
+    const port = await getPort()
+    expect(port).toEqual(3000)
+  })
 
-    afterEach(() => {
-      portBlocker?.close()
-    })
+  test('default port is IN USE', async () => {
+    portBlocker = await blockPort(3000, '0.0.0.0')
+    const port = await getPort()
+    expect(port).toEqual(4000)
+  })
 
-    test('default port is NOT IN USE', async () => {
-      const port = await getPort({ host: 'localhost' })
-      expect(port).toEqual(3000)
-    })
+  test('some of default ports are IN USE', async () => {
+    const defaultPorts = [3000, 4000, 5000, 7000]
+    portBlockers = await blockPorts(defaultPorts, '0.0.0.0')
 
-    test('default port is IN USE', async () => {
-      portBlocker = await blockPort(3000, 'localhost')
-      const port = await getPort({ host: 'localhost' })
-      expect(port).toEqual(4000)
-    })
+    const port = await getPort()
+
+    expect(port).toEqual(6000)
+  })
+
+  test('all default ports are IN USE', async () => {
+    const defaultPorts = [3000, 4000, 5000, 6000, 7000]
+    portBlockers = await blockPorts(defaultPorts, '0.0.0.0')
+
+    const port = await getPort()
+
+    expect(port).toBeGreaterThanOrEqual(1024)
+    expect(port).toBeLessThanOrEqual(65535)
+    expect(defaultPorts).not.toContain(port)
+  })
+
+  test('requested port is NOT IN USE', async () => {
+    const port = await getPort(3456)
+    expect(port).toEqual(3456)
+  })
+
+  test('requested port is IN USE', async () => {
+    portBlocker = await blockPort(3456, '0.0.0.0')
+    const port = await getPort(3456)
+    expect(port).toEqual(4000)
+  })
+
+  test('called with a number', async () => {
+    const port = await getPort('5050')
+    expect(port).toEqual(5050)
+  })
+
+  test('called with a string parsable to a number', async () => {
+    const port = await getPort('5050')
+    expect(port).toEqual(5050)
+  })
+
+  test('called with a string NOT parsable to a number', async () => {
+    const port = await getPort('fifty-fifty')
+    expect(port).toEqual(4000)
+  })
+
+  test.skip('the requested port is privileged', async () => { // for MacOS only
+    const port = await getPort(1010)
+    expect(port).toEqual(4000)
   })
 })

--- a/test/process.env.test.ts
+++ b/test/process.env.test.ts
@@ -1,31 +1,60 @@
 import { Server } from 'net'
+import { getPort } from '../src'
 import { blockPort } from './utils'
 
-describe('getPort (host)', () => {
-  const ENV = process.env
-  let portBlocker: Server
+let rollBackEnv: typeof process.env
+let portBlocker: Server
 
-  beforeEach(() => {
-    jest.resetModules()
-    process.env = ENV
-  })
+beforeEach(() => {
+  rollBackEnv = Object.assign({}, process.env)
+})
 
-  afterEach(() => {
-    process.env = ENV
-    portBlocker?.close()
-  })
+afterEach(() => {
+  portBlocker?.close()
+  process.env = rollBackEnv
+})
 
-  test('default port is not use', async () => {
-    const { getPort } = await import('../src')
+describe('process.env.HOST', () => {
+  test('default port is NOT IN USE', async () => {
+    process.env.HOST = '0.0.0.0'
     const port = await getPort()
     expect(port).toEqual(3000)
   })
 
-  test('default port is in use', async () => {
-    process.env.HOST = 'localhost'
-    const { getPort } = await import('../src')
-    portBlocker = await blockPort(3000, 'localhost')
+  test('default port is IN USE', async () => {
+    process.env.HOST = '127.0.0.1'
+    portBlocker = await blockPort(3000, '127.0.0.1')
+
     const port = await getPort()
+
     expect(port).toEqual(4000)
+  })
+
+  test('called with not valid value', async () => {
+    process.env.HOST = 'not-valid-host'
+    await expect(getPort()).rejects.toThrow()
+  })
+})
+
+describe('process.env.PORT', () => {
+  test('the requested port is NOT IN USE', async () => {
+    process.env.PORT = '3456'
+    const port = await getPort()
+    expect(port).toEqual(3456)
+  })
+
+  test('the requested port is IN USE', async () => {
+    process.env.PORT = '3456'
+    portBlocker = await blockPort(3456, '0.0.0.0')
+
+    const port = await getPort()
+
+    expect(port).toEqual(4000)
+  })
+
+  test('called with not valid value', async () => {
+    process.env.PORT = 'fifty-fifty'
+    const port = await getPort()
+    expect(port).toEqual(3000)
   })
 })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,15 +1,16 @@
 import { createServer, Server } from 'net'
 
-export function blockPort (port: number, host = '0.0.0.0'): Promise<Server> {
+export function blockPort (port: number, host: string): Promise<Server> {
   return new Promise((resolve) => {
     const blocker = createServer()
+    blocker.on('error', (err) => { throw err })
     blocker.listen(port, host, () => {
       resolve(blocker)
     })
   })
 }
 
-export async function blockPorts (ports: number[], host = '0.0.0.0'): Promise<Server[]> {
+export async function blockPorts (ports: number[], host: string): Promise<Server[]> {
   const portBlockers: Server[] = []
 
   for (const port of ports) {


### PR DESCRIPTION
As discussed, here is solution with an array of hosts. What you think?

NEXT: I will work on `getPort(port: number)`. Would be more useful to have `port: number | string`.