### PR TITLE
feat: export `checkPort` utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ or npm install get-port-please
 ```
 
 ```js
-const { getPort } = require('get-port-please')
+const { getPort, checkPort } = require('get-port-please')
 // or
-import { getPort } from 'get-port-please'
+import { getPort, checkPort } from 'get-port-please'
 ```
 
 ```ts
 function getPort(options?: GetPortOptions): Promise<number>
+function checkPort(port: number, host?: string): Promise<number | false>
 ```
 
 Try sequence is: port > ports > memo > random

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export async function getPort (config?: GetPortInput): Promise<number> {
   return availablePort
 }
 
-export async function checkPorts (ports: number[], host: string): Promise<number> {
+export async function checkPorts (ports: number[], host?: string): Promise<number> {
   for (const port of ports) {
     const r = await checkPort(port, host)
     if (r) {
@@ -69,7 +69,7 @@ export async function checkPorts (ports: number[], host: string): Promise<number
   return checkPort(0, host) as unknown as number
 }
 
-export function checkPort (port: number, host: string): Promise<number|false> {
+export function checkPort (port: number, host: string = process.env.HOST || '0.0.0.0'): Promise<number|false> {
   return new Promise((resolve) => {
     const server = createServer()
     server.unref()

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export async function getPort (config?: GetPortInput): Promise<number> {
   return availablePort
 }
 
-async function checkPorts (ports: number[], host: string): Promise<number> {
+export async function checkPorts (ports: number[], host: string): Promise<number> {
   for (const port of ports) {
     const r = await checkPort(port, host)
     if (r) {
@@ -69,7 +69,7 @@ async function checkPorts (ports: number[], host: string): Promise<number> {
   return checkPort(0, host) as unknown as number
 }
 
-function checkPort (port: number, host: string): Promise<number|false> {
+export function checkPort (port: number, host: string): Promise<number|false> {
   return new Promise((resolve) => {
     const server = createServer()
     server.unref()


### PR DESCRIPTION
User could reuse the same logic to check the port in different timing if needed.