### PR TITLE
fix: use `process.env.PORT` as default value if `port` option is missing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export async function getPort (config: GetPortInput = {}): Promise<PortNumber> {
     host: undefined,
     verbose: false,
     ...config,
-    port: Number.parseInt(process.env.PORT || "") || config.port || 3000
+    port: config.port || Number.parseInt(process.env.PORT || "") || 3000
   } as GetPortOptions;
 
   if (options.random) {


### PR DESCRIPTION
resolves #26