### PR TITLE
fix: skip port on any listen error

### DIFF
--- a/src/_internal.ts
+++ b/src/_internal.ts
@@ -37,13 +37,8 @@ export function _tryPort(
   return new Promise((resolve) => {
     const server = createServer();
     server.unref();
-    server.on("error", (error: Error & { code: string }) => {
-      // Ignore invalid host
-      if (error.code === "EINVAL" || error.code === "EADDRNOTAVAIL") {
-        resolve(port !== 0 && isSafePort(port) && port);
-      } else {
-        resolve(false);
-      }
+    server.on("error", () => {
+      resolve(false);
     });
     server.listen({ port, host }, () => {
       const { port } = server.address() as AddressInfo;


### PR DESCRIPTION
- test: skip invalid host tests on windows
- style: lint
- fix: skip all listen errors

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously we were silently ignoring some specific listen errors (`EINVAL` and `EADDRNOTAVAIL`) mainly due to windows IPv6 issues. Now that error handling is better, i think it makes sense to avoid this and find and fix and possible root causes 

(if this PR might introduce any regressions, i really apologize, please ping me in an issue to quickly check and fix!)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
