### PR TITLE
feat: automatically fallback hostname for invalid hosts

### DIFF
--- a/src/_internal.ts
+++ b/src/_internal.ts
@@ -15,7 +15,7 @@ export class GetPortError extends Error {
 
 export function _log(verbose: boolean, message: string) {
   if (verbose) {
-    console.log("[get-port]", message);
+    console.log(`[get-port] ${message}`);
   }
 }
 
@@ -77,9 +77,20 @@ export function _fmtOnHost(hostname: string | undefined) {
 
 const HOSTNAME_RE = /^(?!-)[\d.A-Za-z-]{1,63}(?<!-)$/;
 
-export function _validateHostname(hostname: string | undefined) {
+export function _validateHostname(
+  hostname: string | undefined,
+  _public: boolean,
+  verbose: boolean,
+) {
   if (hostname && !HOSTNAME_RE.test(hostname)) {
-    throw new GetPortError(`Invalid host: ${JSON.stringify(hostname)}`);
+    const fallbackHost = _public ? "0.0.0.0" : "127.0.0.1";
+    _log(
+      verbose,
+      `Invalid hostname: ${JSON.stringify(hostname)}. Using ${JSON.stringify(
+        fallbackHost,
+      )}`,
+    );
+    return fallbackHost;
   }
   return hostname;
 }

--- a/src/get-port.ts
+++ b/src/get-port.ts
@@ -37,7 +37,11 @@ export async function getPort(
     verbose: false,
     ..._userOptions,
     port: _port,
-    host: _validateHostname(_userOptions.host ?? process.env.HOST),
+    host: _validateHostname(
+      _userOptions.host ?? process.env.HOST,
+      _userOptions.public,
+      _userOptions.verbose,
+    ),
   } as GetPortOptions;
 
   if (options.random) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface GetPortOptions {
   alternativePortRange: [from: number, to: number];
   host: string;
   verbose?: boolean;
+  public?: boolean;
 }
 
 export interface WaitForPortOptions {


### PR DESCRIPTION


### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

resolves #57

When hostname is (misconfigured) and invalid, instead of throwing a hard error, get-port listens on a fallback (IPv4) hostname (127.0.0.1 or 0.0.0.0 if `public` flag is explicitly set)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
