### PR TITLE
fix: explicit `port/portRange` even if `random` is `true`

### DIFF
--- a/src/_internal.ts
+++ b/src/_internal.ts
@@ -19,13 +19,24 @@ export function _log(verbose: boolean, message: string) {
   }
 }
 
-export function _generateRange(from: number, to: number): number[] {
+export function _generateRange(
+  range: [from: number, to: number],
+  random?: boolean,
+): number[] {
+  const [from, to] = range;
   if (to < from) {
     return [];
   }
   const r = [];
   for (let index = from; index < to; index++) {
     r.push(index);
+  }
+  // Fisher-Yates shuffle algorithm
+  if (random) {
+    for (let i = r.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [r[i], r[j]] = [r[j], r[i]];
+    }
   }
   return r;
 }

--- a/src/get-port.ts
+++ b/src/get-port.ts
@@ -44,15 +44,14 @@ export async function getPort(
     ),
   } as GetPortOptions;
 
-  if (options.random) {
+  if (options.random && options.portRange.length === 0 as number) {
     return getRandomPort(options.host);
   }
 
   // Generate list of ports to check
   const portsToCheck: PortNumber[] = [
-    options.port,
-    ...options.ports,
-    ..._generateRange(...options.portRange),
+    ...(options.random ? [] : [options.port, ...options.ports]),
+    ..._generateRange(options.portRange, options.random)
   ].filter((port) => {
     if (!port) {
       return false;
@@ -70,7 +69,7 @@ export async function getPort(
   // Try fallback port range
   if (!availablePort && options.alternativePortRange.length > 0) {
     availablePort = await _findPort(
-      _generateRange(...options.alternativePortRange),
+      _generateRange(options.alternativePortRange),
       options.host,
     );
     _log(


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/unjs/get-port-please/issues/65

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
