### PR TITLE
fix: ranges now work even if port is unset in options

### DIFF
--- a/src/get-port.ts
+++ b/src/get-port.ts
@@ -26,7 +26,6 @@ export async function getPort(
     _userOptions = { port: Number.parseInt(_userOptions + "") || 0 };
   }
 
-  const defaultPort = 3000;
   const _port = Number(_userOptions.port ?? process.env.PORT);
 
   const options = {
@@ -54,7 +53,6 @@ export async function getPort(
     options.port,
     ...options.ports,
     ..._generateRange(...options.portRange),
-    defaultPort,
   ].filter((port) => {
     if (!port) {
       return false;
@@ -65,6 +63,9 @@ export async function getPort(
     }
     return true;
   });
+  if (portsToCheck.length === 0) {
+    portsToCheck.push(3000);
+  }
 
   // Try to find a port
   let availablePort = await _findPort(portsToCheck, options.host);

--- a/src/get-port.ts
+++ b/src/get-port.ts
@@ -26,7 +26,8 @@ export async function getPort(
     _userOptions = { port: Number.parseInt(_userOptions + "") || 0 };
   }
 
-  const _port = Number(_userOptions.port ?? process.env.PORT ?? 3000);
+  const defaultPort = 3000;
+  const _port = Number(_userOptions.port ?? process.env.PORT);
 
   const options = {
     name: "default",
@@ -53,6 +54,7 @@ export async function getPort(
     options.port,
     ...options.ports,
     ..._generateRange(...options.portRange),
+    defaultPort,
   ].filter((port) => {
     if (!port) {
       return false;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -13,7 +13,7 @@ describe("getPort", () => {
     portBlocker?.close();
   });
 
-  describe("default host`", () => {
+  describe("default host", () => {
     test("default port is not in use", async () => {
       const port = await getPort();
       expect(port).toEqual(3000);
@@ -23,6 +23,13 @@ describe("getPort", () => {
       portBlocker = await blockPort(3000);
       const port = await getPort();
       expect(port).toEqual(3001);
+    });
+  });
+
+  describe("order", () => {
+    test("`ports` is preferred", async () => {
+      const port = await getPort({ ports: [8080] });
+      expect(port).toEqual(8080);
     });
   });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -117,7 +117,7 @@ describe("errors", () => {
       random: false,
     }).catch((error) => error);
     expect(error.toString()).toMatchInlineSnapshot(
-      `"GetPortError: Unable to find an available port on host "192.168.1.999" (tried 3000, 3000-3100)"`,
+      `"GetPortError: Unable to find an available port on host "192.168.1.999" (tried 3000-3100)"`,
     );
   });
 });


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/unjs/get-port-please/issues/67

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Moved default port to the end of the queue of ports to check (instead of the head of the
queue, as previously).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
