### PR TITLE
fix: improve log when using alternative port

### DIFF
--- a/src/get-port.ts
+++ b/src/get-port.ts
@@ -73,15 +73,14 @@ export async function getPort(
       _generateRange(...options.alternativePortRange),
       options.host,
     );
-    if (portsToCheck.length > 0 && availablePort) {
-      _log(
-        options.verbose,
-        `Unable to find an available port (tried ${portsToCheck.join(
-          "-",
-        )} ${_fmtOnHost(
-          options.host,
-        )}). Using alternative port ${availablePort}`,
-      );
+    if (portsToCheck.length > 0) {
+      let message = `Unable to find an available port (tried ${portsToCheck.join(
+        "-",
+      )} ${_fmtOnHost(options.host)}).`;
+      if (availablePort) {
+        message += ` Using alternative port ${availablePort}.`;
+      }
+      _log(options.verbose, message);
     }
   }
 

--- a/src/get-port.ts
+++ b/src/get-port.ts
@@ -74,6 +74,7 @@ export async function getPort(
       options.host,
     );
     if (portsToCheck.length > 0) {
+      console.log({ portsToCheck })
       let message = `Unable to find an available port (tried ${portsToCheck.join(
         "-",
       )} ${_fmtOnHost(options.host)}).`;

--- a/src/get-port.ts
+++ b/src/get-port.ts
@@ -74,7 +74,7 @@ export async function getPort(
       options.host,
     );
     if (portsToCheck.length > 0) {
-      console.log({ portsToCheck })
+      console.log({ portsToCheck });
       let message = `Unable to find an available port (tried ${portsToCheck.join(
         "-",
       )} ${_fmtOnHost(options.host)}).`;

--- a/src/get-port.ts
+++ b/src/get-port.ts
@@ -73,12 +73,16 @@ export async function getPort(
       _generateRange(...options.alternativePortRange),
       options.host,
     );
-    _log(
-      options.verbose,
-      `Unable to find an available port (tried ${options.alternativePortRange.join(
-        "-",
-      )} ${_fmtOnHost(options.host)}). Using alternative port ${availablePort}`,
-    );
+    if (portsToCheck.length > 0 && availablePort) {
+      _log(
+        options.verbose,
+        `Unable to find an available port (tried ${portsToCheck.join(
+          "-",
+        )} ${_fmtOnHost(
+          options.host,
+        )}). Using alternative port ${availablePort}`,
+      );
+    }
   }
 
   // Try random port

--- a/src/get-port.ts
+++ b/src/get-port.ts
@@ -74,7 +74,6 @@ export async function getPort(
       options.host,
     );
     if (portsToCheck.length > 0) {
-      console.log({ portsToCheck });
       let message = `Unable to find an available port (tried ${portsToCheck.join(
         "-",
       )} ${_fmtOnHost(options.host)}).`;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This no longer logs if an empty array is passed in `portsToCheck`, and also corrects the log message so it doesn't say that it failed to find a port in the range that _did_ produce a port.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
