### PR TITLE
feat: add unix domain socket utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ import {
   getRandomPort,
   waitForPort,
   getSocketAddress,
-  isSocketSupported
+  isSocketSupported,
+  cleanSocket
 } from "get-port-please";
 
 // CommonJS
@@ -34,6 +35,7 @@ const {
   waitForPort,
   getSocketAddress,
   isSocketSupported,
+  cleanSocket
 } = require("get-port-please");
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ import {
   checkPort,
   getRandomPort,
   waitForPort,
+  getSocketAddress,
+  isSocketSupported
 } from "get-port-please";
 
 // CommonJS
@@ -30,6 +32,8 @@ const {
   checkPort,
   getRandomPort,
   waitForPort,
+  getSocketAddress,
+  isSocketSupported,
 } = require("get-port-please");
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 export * from "./get-port";
 export * from "./unsafe-ports";
+export * from "./socket";

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -1,0 +1,85 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Server } from "node:net"
+
+export interface GetSocketOptions {
+  /* Human readable prefix for the socket name */
+  name: string;
+
+  /**
+   * Use process ID in the socket name.
+   */
+  pid?: boolean;
+
+  /**
+   * Use a random number in the socket name.
+   *
+   */
+  random?: boolean;
+}
+
+let _nodeMajorVersion: number | undefined;
+let _isSocketSupported: boolean | undefined;
+
+/**
+ * Generates a socket address based on the provided options.
+ */
+export function getSocketAddress(opts: GetSocketOptions): string {
+  const parts = [
+    opts.name,
+    opts.pid ? process.pid : undefined,
+    opts.random ? Math.round(Math.random() * 10_000) : undefined
+  ].filter(Boolean);
+
+  const socketName = `${parts.join("-")}.sock`;
+
+  // Windows: pipe
+  if (process.platform === "win32") {
+    return join(String.raw`\\.\pipe`, socketName);
+  }
+
+  // Linux: abstract namespace
+  // Fallback to a regular file socket on older Node.js versions to avoid issues
+  if (process.platform === "linux") {
+    if (_nodeMajorVersion === undefined) {
+      _nodeMajorVersion = +process.versions.node.split(".")[0];
+    }
+    if (_nodeMajorVersion >= 20) {
+      return `\0${socketName}`;
+    }
+  }
+
+  // Unix socket
+  return join(tmpdir(), socketName);
+}
+
+/**
+ * Test if the current environment supports sockets.
+ */
+export async function isSocketSupported(): Promise<boolean> {
+  if (_isSocketSupported !== undefined) {
+    return _isSocketSupported;
+  }
+  if (globalThis.process?.versions?.webcontainer) {
+    // Seems broken: https://stackblitz.com/edit/stackblitz-starters-1y68uhvu
+    return false;
+  }
+
+  const socketAddress = getSocketAddress({ name: "get-port", random: true });
+  const server = new Server()
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", reject);
+      server.listen(socketAddress, resolve);
+    });
+    _isSocketSupported = true;
+    return true;
+  } catch {
+    _isSocketSupported = false;
+    return false
+  } finally {
+    if (server.listening) {
+      server.close();
+    }
+  }
+}

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -1,6 +1,6 @@
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Server } from "node:net"
+import { Server } from "node:net";
 
 export interface GetSocketOptions {
   /* Human readable prefix for the socket name */
@@ -28,7 +28,7 @@ export function getSocketAddress(opts: GetSocketOptions): string {
   const parts = [
     opts.name,
     opts.pid ? process.pid : undefined,
-    opts.random ? Math.round(Math.random() * 10_000) : undefined
+    opts.random ? Math.round(Math.random() * 10_000) : undefined,
   ].filter(Boolean);
 
   const socketName = `${parts.join("-")}.sock`;
@@ -66,7 +66,7 @@ export async function isSocketSupported(): Promise<boolean> {
   }
 
   const socketAddress = getSocketAddress({ name: "get-port", random: true });
-  const server = new Server()
+  const server = new Server();
   try {
     await new Promise<void>((resolve, reject) => {
       server.on("error", reject);
@@ -76,7 +76,7 @@ export async function isSocketSupported(): Promise<boolean> {
     return true;
   } catch {
     _isSocketSupported = false;
-    return false
+    return false;
   } finally {
     if (server.listening) {
       server.close();

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -91,5 +91,5 @@ export async function cleanSocket(path: string): Promise<void> {
     // Abstract namespace sockets or invalid paths
     return;
   }
-  return rm(path, { force: true, recursive: true }).catch(() => {})
+  return rm(path, { force: true, recursive: true }).catch(() => {});
 }

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -91,5 +91,5 @@ export async function cleanSocket(path: string): Promise<void> {
     // Abstract namespace sockets or invalid paths
     return;
   }
-  return rm(path, { force: true, recursive: true }).catch(() => {});
+  return rm(path, { force: true, recursive: true }).catch(console.error);
 }

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -1,6 +1,7 @@
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Server } from "node:net";
+import { rm } from "node:fs/promises";
 
 export interface GetSocketOptions {
   /* Human readable prefix for the socket name */
@@ -80,6 +81,15 @@ export async function isSocketSupported(): Promise<boolean> {
   } finally {
     if (server.listening) {
       server.close();
+      await cleanSocket(socketAddress);
     }
   }
+}
+
+export async function cleanSocket(path: string): Promise<void> {
+  if (!path || path[0] === "\0" || path.startsWith(String.raw`\\.\pipe`)) {
+    // Abstract namespace sockets or invalid paths
+    return;
+  }
+  return rm(path, { force: true, recursive: true }).catch(() => {})
 }

--- a/test/socket.test.ts
+++ b/test/socket.test.ts
@@ -4,9 +4,9 @@ import { isSocketSupported, getSocketAddress } from "../src";
 describe("socket", () => {
   test("isSocketSupported", async () => {
     expect(await isSocketSupported()).toBe(true);
-  })
+  });
   test("getSocketAddress", async () => {
     const addr = getSocketAddress({ name: "test", pid: true, random: true });
     expect(addr).toMatch(/test-\d+-\d+\.sock/);
-  })
-})
+  });
+});

--- a/test/socket.test.ts
+++ b/test/socket.test.ts
@@ -1,0 +1,12 @@
+import { describe, test, expect } from "vitest";
+import { isSocketSupported, getSocketAddress } from "../src";
+
+describe("socket", () => {
+  test("isSocketSupported", async () => {
+    expect(await isSocketSupported()).toBe(true);
+  })
+  test("getSocketAddress", async () => {
+    const addr = getSocketAddress({ name: "test", pid: true, random: true });
+    expect(addr).toMatch(/test-\d+-\d+\.sock/);
+  })
+})


### PR DESCRIPTION
closes #91

This PR adds `getSocketAddress` utility to get an optimal socket path (pipe in windows, abstract socket in linux and normal socket in other envs, like MacOS)

Also a `isSocketSupported` utility is exposed to try make sure actual OS supports sockets