### PR TITLE
fix: detect port collisions with wildcard addresses when host is loopback (#121)

### DIFF
--- a/src/_internal.ts
+++ b/src/_internal.ts
@@ -66,12 +66,48 @@ export function _getLocalHosts(additional: HostAddress[]): HostAddress[] {
   return [...hosts];
 }
 
+/**
+ * Check if a port is available on all given hosts.
+ * A port is only considered available if _tryPort succeeds on every host.
+ */
+async function _tryPortAll(
+  port: PortNumber,
+  hosts: HostAddress[],
+): Promise<PortNumber | false> {
+  for (const host of hosts) {
+    const r = await _tryPort(port, host);
+    if (r === false) {
+      return false;
+    }
+    if (port === 0 && r !== 0) {
+      port = r;
+    }
+  }
+  return port;
+}
+
+/**
+ * Expand a loopback hostname to include wildcard addresses for collision detection.
+ * When a server is bound to 0.0.0.0 or [::], it occupies the port on ALL interfaces,
+ * but _tryPort with a specific address won't detect that. This helper ensures wildcard
+ * collisions are also detected.
+ */
+function _expandHostsForCollision(host: HostAddress): HostAddress[] {
+  const hostStr = String(host).toLowerCase();
+  const loopback = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+  if (loopback.has(hostStr)) {
+    return [...new Set([host, "0.0.0.0", "::"])];
+  }
+  return [host];
+}
+
 export async function _findPort(
   ports: number[],
   host: HostAddress,
 ): Promise<PortNumber> {
+  const hosts = _expandHostsForCollision(host);
   for (const port of ports) {
-    const r = await _tryPort(port, host);
+    const r = await _tryPortAll(port, hosts);
     if (r) {
       return r;
     }


### PR DESCRIPTION
### 🔗 Linked issue

Closes #121

### 📝 Description

When a `host` is explicitly passed to `getPort()`, collisions with servers bound to wildcard addresses (`0.0.0.0`, `[::]`) are not detected.

**Reproduction:**
1. Start a server bound to `0.0.0.0:3000`
2. Call `getPort({ host: 'localhost', port: 3000 })`
3. It returns `3000` instead of detecting the collision

**Root cause:** `_findPort` calls `_tryPort(port, host)` with only the specified host. When `host` is `localhost`, it only tries to bind on `127.0.0.1` (or `::1`), which succeeds even though `0.0.0.0:3000` is occupied.

The existing logic in `checkPort()` already handles this correctly when **no host** is passed (it expands to all local hosts including `0.0.0.0`). But when a specific host is provided, only that single address is checked.

### Fix

1. Added `_expandHostsForCollision()` — when the host is a loopback address (`localhost`, `127.0.0.1`, `::1`), it expands to `[host, '0.0.0.0', '::']` so wildcard collisions are detected.
2. Added `_tryPortAll()` — checks a port against all expanded hosts; a port is only considered available if it can bind on every address.
3. Updated `_findPort()` to use `_expandHostsForCollision` + `_tryPortAll` instead of raw `_tryPort`.

Non-loopback hosts (e.g., a specific LAN IP) are not affected — they still check only the single address.

### Testing

The existing test suite should pass. The fix adds collision detection for the specific case described in #121 without changing behavior for other cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port availability detection for loopback addresses (localhost, 127.0.0.1, ::1). The system now validates ports against both loopback and wildcard addresses to prevent false positives and ensure more reliable port allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->