### PR TITLE
fix: handle EAFNOSUPPORT as non-collision in _tryPort

### DIFF
--- a/src/_internal.ts
+++ b/src/_internal.ts
@@ -37,8 +37,14 @@ export function _tryPort(
   return new Promise((resolve) => {
     const server = createServer();
     server.unref();
-    server.on("error", () => {
-      resolve(false);
+    server.on("error", (err: any) => {
+      // EAFNOSUPPORT means the address family isn't supported (e.g., IPv6 on IPv4-only systems).
+      // Treat as non-collision (port is available for this address family).
+      if (err?.code === "EAFNOSUPPORT") {
+        resolve(isSafePort(port) && port);
+      } else {
+        resolve(false);
+      }
     });
     server.listen({ port, host }, () => {
       const { port } = server.address() as AddressInfo;


### PR DESCRIPTION
Follow-up to #122. When probing for port availability on IPv6 (`::`) from IPv4-only systems, the socket error code is `EAFNOSUPPORT` (address family not supported). This was previously treated as port-in-use, causing all ports to appear unavailable on systems without IPv6.

Now `EAFNOSUPPORT` errors are treated as non-collisions (port available) since the address family simply isn't applicable.

This is a targeted fix in `_tryPort` rather than conditionally gating the `::` probe in `_expandHostsForCollision`, as it's simpler and handles any future address-family probing edge cases.

Addresses CodeRabbit review on #122.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced port availability detection to properly handle unsupported address family errors, allowing more accurate identification of usable ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->